### PR TITLE
fix: portable mode with fallback to user home for PADDLE_PDX_CACHE_HOME

### DIFF
--- a/PaddleOCR-Standalone/Wrappers/CPU/wrapper.py
+++ b/PaddleOCR-Standalone/Wrappers/CPU/wrapper.py
@@ -26,11 +26,54 @@
 #     nuitka-project: --copyright="timminator"
 #     nuitka-project: --windows-icon-from-ico=paddleocr.ico
 
+# ============================================================
+# Portable mode with fallback to user home
+#
+# Priority:
+#   1. ./.paddlex/temp  (portable, next to the exe)
+#   2. $USERPROFILE/.paddlex  (fallback for restricted dirs,
+#      e.g. C:\Program Files, Citrix multi-user environments)
+#
+# The fallback is triggered when the process lacks write
+# permission on the exe directory (WinError 5 / EACCES).
+# ============================================================
+import os
+import pathlib
+
+
+def _resolve_paddlex_home() -> pathlib.Path:
+    exe_dir = pathlib.Path(os.path.dirname(os.path.abspath(__file__)))
+    portable_home = exe_dir / ".paddlex"
+    try:
+        (portable_home / "temp").mkdir(parents=True, exist_ok=True)
+        return portable_home
+    except PermissionError:
+        pass
+
+    # Fallback: use the real user home directory.
+    # Under Nuitka on Windows, pathlib.Path.home() may resolve to
+    # the exe directory instead of USERPROFILE, so we read the
+    # environment variable directly.
+    user_home = (
+        os.environ.get("USERPROFILE")
+        or os.environ.get("HOME")
+        or str(pathlib.Path.home())
+    )
+    user_paddlex = pathlib.Path(user_home) / ".paddlex"
+    (user_paddlex / "temp").mkdir(parents=True, exist_ok=True)
+    (user_paddlex / "official_models").mkdir(parents=True, exist_ok=True)
+    return user_paddlex
+
+
+_paddlex_home = _resolve_paddlex_home()
+# ============================================================
+# END
+# ============================================================
 
 import sys
 import os
 
-os.environ["PADDLE_PDX_CACHE_HOME"] = os.path.join(os.path.dirname(os.path.abspath(__file__)), ".paddlex")
+os.environ["PADDLE_PDX_CACHE_HOME"] = str(_paddlex_home)
 os.environ["PADDLE_PDX_DISABLE_MODEL_SOURCE_CHECK"] = "True"
 
 from paddleocr.__main__ import console_entry

--- a/PaddleOCR-Standalone/Wrappers/GPU/wrapper.py
+++ b/PaddleOCR-Standalone/Wrappers/GPU/wrapper.py
@@ -26,11 +26,54 @@
 #     nuitka-project: --copyright="timminator"
 #     nuitka-project: --windows-icon-from-ico=paddleocr.ico
 
+# ============================================================
+# Portable mode with fallback to user home
+#
+# Priority:
+#   1. ./.paddlex/temp  (portable, next to the exe)
+#   2. $USERPROFILE/.paddlex  (fallback for restricted dirs,
+#      e.g. C:\Program Files, Citrix multi-user environments)
+#
+# The fallback is triggered when the process lacks write
+# permission on the exe directory (WinError 5 / EACCES).
+# ============================================================
+import os
+import pathlib
+
+
+def _resolve_paddlex_home() -> pathlib.Path:
+    exe_dir = pathlib.Path(os.path.dirname(os.path.abspath(__file__)))
+    portable_home = exe_dir / ".paddlex"
+    try:
+        (portable_home / "temp").mkdir(parents=True, exist_ok=True)
+        return portable_home
+    except PermissionError:
+        pass
+
+    # Fallback: use the real user home directory.
+    # Under Nuitka on Windows, pathlib.Path.home() may resolve to
+    # the exe directory instead of USERPROFILE, so we read the
+    # environment variable directly.
+    user_home = (
+        os.environ.get("USERPROFILE")
+        or os.environ.get("HOME")
+        or str(pathlib.Path.home())
+    )
+    user_paddlex = pathlib.Path(user_home) / ".paddlex"
+    (user_paddlex / "temp").mkdir(parents=True, exist_ok=True)
+    (user_paddlex / "official_models").mkdir(parents=True, exist_ok=True)
+    return user_paddlex
+
+
+_paddlex_home = _resolve_paddlex_home()
+# ============================================================
+# END
+# ============================================================
 
 import sys
 import os
 
-os.environ["PADDLE_PDX_CACHE_HOME"] = os.path.join(os.path.dirname(os.path.abspath(__file__)), ".paddlex")
+os.environ["PADDLE_PDX_CACHE_HOME"] = str(_paddlex_home)
 os.environ["PADDLE_PDX_DISABLE_MODEL_SOURCE_CHECK"] = "True"
 
 from paddleocr.__main__ import console_entry


### PR DESCRIPTION
## Problem

When `paddleocr.exe` is installed in a restricted directory such as
`C:\Program Files` or `C:\Program Files (x86)`, PaddleX fails on startup
with a `PermissionError` (Windows Error 5) when trying to create
`.paddlex\temp` next to the executable:
```
PermissionError: [WinError 5] Access is denied:
'C:\\Program Files (x86)\\...\\paddle-ocr\\.paddlex\\temp'
```

This also affects **multi-user environments** (e.g. Citrix, RDS/Terminal
Server) where the exe lives in a shared read-only directory: all users
would compete to write into the same `.paddlex\temp`, causing race
conditions and permission errors.

Setting `PADDLEX_HOME` as an environment variable has no effect because
`PADDLE_PDX_CACHE_HOME` is hardcoded in `wrapper.py` to always point to
the exe directory, overriding any external configuration.

Additionally, under Nuitka on Windows, `pathlib.Path.home()` may resolve
to the exe directory instead of `%USERPROFILE%`, making a simple
`Path.home()` fallback unreliable.

## Solution

Introduce a **portable-first with user-home fallback** strategy in
`wrapper.py`:

1. **Try portable mode first**: attempt to create `.paddlex/temp` next to
   the exe (original behavior, keeps backward compatibility for users who
   install in a writable directory).
2. **Fallback to user home**: if a `PermissionError` is raised, resolve
   the real user home via `%USERPROFILE%` (or `%HOME%`) and use
   `$USERPROFILE\.paddlex` instead.

This ensures:
- ✅ Existing portable installations continue to work unchanged
- ✅ System-wide installations in `C:\Program Files` work without admin rights
- ✅ Each user in a multi-user/Citrix environment gets their own isolated
  cache under their own profile

## Changes

- `Wrappers/CPU/wrapper.py`: replace hardcoded `PADDLE_PDX_CACHE_HOME`
  with `_resolve_paddlex_home()` which implements the portable/fallback logic

## Testing

Tested on Windows 11 with:
- ✅ Portable mode: exe in `C:\Users\<user>\test\` → uses `.\\.paddlex`
- ✅ Fallback mode: exe in `C:\Program Files (x86)\...` → uses
  `C:\Users\<user>\.paddlex`
- ✅ Citrix multi-user: each user session resolves to their own
  `%USERPROFILE%\.paddlex`